### PR TITLE
[feat] select 구현

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,10 @@
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>
         <div id="root"></div>
+        <script
+            src="https://kit.fontawesome.com/7c33dc4bb4.js"
+            crossorigin="anonymous"
+        ></script>
         <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -2,15 +2,18 @@ import { useState } from "react";
 import styled from "styled-components";
 
 export default function Input() {
+    // 이름, 가격 Input 상태
     const [name, setName] = useState("");
     const [price, setPrice] = useState("0");
 
+    // 입력한 숫자 3자리 수마다 콤마가 찍히는 로직
     const priceInputHandler = (e) => {
         const priceStr = e.target.value;
         const priceNum = Number(priceStr.replaceAll(",", ""));
         setPrice(priceNum.toLocaleString());
     };
 
+    // 저장 버튼 클릭 시 이벤트
     const btnClickHandler = () => {
         if (name === "") {
             alert("이름과 가격을 입력해주세요.");
@@ -43,6 +46,7 @@ export default function Input() {
 
 const InputContainerStyle = styled.div`
     #price {
+        /* 이름 - 가격 input 간 간격 설정 */
         margin-left: 1.5rem;
     }
 

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -3,12 +3,20 @@ import styled from "styled-components";
 
 export default function Input() {
     const [name, setName] = useState("");
-    const [price, setPrice] = useState("");
+    const [price, setPrice] = useState("0");
 
-    const priceInputHandle = (e) => {
+    const priceInputHandler = (e) => {
         const priceStr = e.target.value;
         const priceNum = Number(priceStr.replaceAll(",", ""));
         setPrice(priceNum.toLocaleString());
+    };
+
+    const btnClickHandler = () => {
+        if (name === "") {
+            alert("이름과 가격을 입력해주세요.");
+        } else {
+            alert(`{ name: ${name}, price: ${price} }`);
+        }
     };
 
     return (
@@ -25,13 +33,9 @@ export default function Input() {
                 <input
                     type="text"
                     value={price}
-                    onChange={priceInputHandle}
+                    onChange={priceInputHandler}
                 ></input>
-                <button
-                    onClick={() => alert(`{ name: ${name}, price: ${price} }`)}
-                >
-                    저장
-                </button>
+                <button onClick={btnClickHandler}>저장</button>
             </InputContainerStyle>
         </>
     );

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -3,13 +3,15 @@ import styled from "styled-components";
 
 export default function Select() {
     const [isOpen, setIsOpen] = useState(false);
+    const [secondOpen, setSecondOpen] = useState(false);
     const [selectOption, setSelectOption] = useState(null);
+    const [selectSecondOption, setSelectSecondOption] = useState(null);
 
     const options = ["React", "JAVA", "Spring", "React Native"];
 
-    const optionClickHandler = (option) => {
-        setSelectOption(option);
-        setIsOpen(false);
+    const optionClickHandler = (option, setSelect, setOpen) => {
+        setSelect(option);
+        setOpen(false);
     };
 
     return (
@@ -27,7 +29,11 @@ export default function Select() {
                                 {options.map((option) => (
                                     <ListItem
                                         onClick={() =>
-                                            optionClickHandler(option)
+                                            optionClickHandler(
+                                                option,
+                                                setSelectOption,
+                                                setIsOpen
+                                            )
                                         }
                                     >
                                         {option}
@@ -38,15 +44,29 @@ export default function Select() {
                     )}
                 </SelectWrapperStyle>
                 <SelectWrapperStyle>
-                    {/* <select>
-                        <option value="" selected>
-                            리액트
-                        </option>
-                        <option>리액트</option>
-                        <option>자바</option>
-                        <option>스프링</option>
-                        <option>리액트 네이티브</option>
-                    </select> */}
+                    <DropdownMain onClick={() => setSecondOpen(!secondOpen)}>
+                        {selectSecondOption || "React"}
+                        <i class="fa-solid fa-chevron-down"></i>
+                    </DropdownMain>
+                    {secondOpen && (
+                        <DropdownListContainer>
+                            <DropdownList>
+                                {options.map((option) => (
+                                    <ListItem
+                                        onClick={() =>
+                                            optionClickHandler(
+                                                option,
+                                                setSelectSecondOption,
+                                                setSecondOpen
+                                            )
+                                        }
+                                    >
+                                        {option}
+                                    </ListItem>
+                                ))}
+                            </DropdownList>
+                        </DropdownListContainer>
+                    )}
                 </SelectWrapperStyle>
             </SelectContentBox>
         </SelectContainer>
@@ -66,24 +86,13 @@ const SelectContainer = styled.div`
 
 const SelectContentBox = styled.div`
     display: flex;
+    gap: 1rem;
 `;
 
 const SelectWrapperStyle = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 1rem;
-
-    select {
-        /* css 설정 초기화 */
-        -moz-appearance: none;
-        -webkit-appearance: none;
-        appearance: none;
-
-        width: 20rem;
-        padding: 0.8rem 1rem;
-        border: 1px solid rgb(221, 221, 221);
-        border-radius: 0.5rem;
-    }
+    gap: 0.7rem;
 `;
 
 const DropdownMain = styled.div`
@@ -91,7 +100,9 @@ const DropdownMain = styled.div`
     padding: 0.8rem 1rem;
     border: 1px solid rgb(221, 221, 221);
     border-radius: 0.5rem;
+
     cursor: pointer;
+
     display: flex;
     justify-content: space-between;
 `;
@@ -101,6 +112,7 @@ const DropdownListContainer = styled.div`
     border-radius: 0.5rem;
     padding: 0;
     background-color: white;
+
     cursor: pointer;
 `;
 

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -43,7 +43,7 @@ export default function Select() {
                         </DropdownListContainer>
                     )}
                 </SelectWrapperStyle>
-                <SelectWrapperStyle>
+                <ShowSelectWrapperStyle>
                     <DropdownMain onClick={() => setSecondOpen(!secondOpen)}>
                         {selectSecondOption || "React"}
                         <i class="fa-solid fa-chevron-down"></i>
@@ -67,7 +67,7 @@ export default function Select() {
                             </DropdownList>
                         </DropdownListContainer>
                     )}
-                </SelectWrapperStyle>
+                </ShowSelectWrapperStyle>
             </SelectContentBox>
         </SelectContainer>
     );
@@ -75,13 +75,15 @@ export default function Select() {
 
 const SelectContainer = styled.div`
     margin-top: 2.5rem;
-    height: 13rem;
+    height: 15rem;
     border: 3px solid rgb(221, 221, 221);
     border-radius: 1rem;
     padding: 0 2rem;
     display: flex;
     flex-direction: column;
-    /* overflow: hidden; */
+
+    overflow: hidden;
+    position: static;
 `;
 
 const SelectContentBox = styled.div`
@@ -93,6 +95,14 @@ const SelectWrapperStyle = styled.div`
     display: flex;
     flex-direction: column;
     gap: 0.7rem;
+`;
+
+const ShowSelectWrapperStyle = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+    position: absolute;
+    margin-left: 23.5rem;
 `;
 
 const DropdownMain = styled.div`

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,1 +1,55 @@
-export default function Select() {}
+import styled from "styled-components";
+
+export default function Select() {
+    return (
+        <SelectContainer>
+            <h1>Select</h1>
+            <SelectWrapperStyle>
+                <select>
+                    <option value="" selected>
+                        리액트
+                    </option>
+                    <option>리액트</option>
+                    <option>자바</option>
+                    <option>스프링</option>
+                    <option>리액트 네이티브</option>
+                </select>
+                <select>
+                    <option value="" selected>
+                        리액트
+                    </option>
+                    <option>리액트</option>
+                    <option>자바</option>
+                    <option>스프링</option>
+                    <option>리액트 네이티브</option>
+                </select>
+            </SelectWrapperStyle>
+        </SelectContainer>
+    );
+}
+
+const SelectContainer = styled.div`
+    margin-top: 2.5rem;
+    height: 10rem;
+    border: 3px solid rgb(221, 221, 221);
+    border-radius: 1rem;
+    padding: 0 2rem;
+    overflow: hidden;
+`;
+
+const SelectWrapperStyle = styled.div`
+    display: flex;
+    gap: 1rem;
+
+    select {
+        /* css 설정 초기화 */
+        -moz-appearance: none;
+        -webkit-appearance: none;
+        appearance: none;
+
+        width: 20rem;
+        padding: 0.8rem 1rem;
+        border: 1px solid rgb(221, 221, 221);
+        border-radius: 0.5rem;
+    }
+`;

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -3,8 +3,10 @@ import FirstSelect from "./select/FirstSelect";
 import SecondSelect from "./select/SecondSelect";
 
 export default function Select() {
+    // select dropdown option
     const options = ["React", "JAVA", "Spring", "React Native"];
 
+    // option 클릭 시 상태 변경
     const optionClickHandler = (option, setSelect, setOpen) => {
         setSelect(option);
         setOpen(false);
@@ -39,6 +41,6 @@ const SelectContainer = styled.div`
 `;
 
 const SelectContentBox = styled.div`
+    /* 두 Select 배치 설정 */
     display: flex;
-    gap: 1rem;
 `;

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,12 +1,8 @@
-import { useState } from "react";
 import styled from "styled-components";
+import FirstSelect from "./select/FirstSelect";
+import SecondSelect from "./select/SecondSelect";
 
 export default function Select() {
-    const [isOpen, setIsOpen] = useState(false);
-    const [secondOpen, setSecondOpen] = useState(false);
-    const [selectOption, setSelectOption] = useState(null);
-    const [selectSecondOption, setSelectSecondOption] = useState(null);
-
     const options = ["React", "JAVA", "Spring", "React Native"];
 
     const optionClickHandler = (option, setSelect, setOpen) => {
@@ -18,56 +14,14 @@ export default function Select() {
         <SelectContainer>
             <h1>Select</h1>
             <SelectContentBox>
-                <SelectWrapperStyle>
-                    <DropdownMain onClick={() => setIsOpen(!isOpen)}>
-                        {selectOption || "React"}
-                        <i class="fa-solid fa-chevron-down"></i>
-                    </DropdownMain>
-                    {isOpen && (
-                        <DropdownListContainer>
-                            <DropdownList>
-                                {options.map((option) => (
-                                    <ListItem
-                                        onClick={() =>
-                                            optionClickHandler(
-                                                option,
-                                                setSelectOption,
-                                                setIsOpen
-                                            )
-                                        }
-                                    >
-                                        {option}
-                                    </ListItem>
-                                ))}
-                            </DropdownList>
-                        </DropdownListContainer>
-                    )}
-                </SelectWrapperStyle>
-                <ShowSelectWrapperStyle>
-                    <DropdownMain onClick={() => setSecondOpen(!secondOpen)}>
-                        {selectSecondOption || "React"}
-                        <i class="fa-solid fa-chevron-down"></i>
-                    </DropdownMain>
-                    {secondOpen && (
-                        <DropdownListContainer>
-                            <DropdownList>
-                                {options.map((option) => (
-                                    <ListItem
-                                        onClick={() =>
-                                            optionClickHandler(
-                                                option,
-                                                setSelectSecondOption,
-                                                setSecondOpen
-                                            )
-                                        }
-                                    >
-                                        {option}
-                                    </ListItem>
-                                ))}
-                            </DropdownList>
-                        </DropdownListContainer>
-                    )}
-                </ShowSelectWrapperStyle>
+                <FirstSelect
+                    options={options}
+                    optionClickHandler={optionClickHandler}
+                />
+                <SecondSelect
+                    options={options}
+                    optionClickHandler={optionClickHandler}
+                />
             </SelectContentBox>
         </SelectContainer>
     );
@@ -79,8 +33,6 @@ const SelectContainer = styled.div`
     border: 3px solid rgb(221, 221, 221);
     border-radius: 1rem;
     padding: 0 2rem;
-    display: flex;
-    flex-direction: column;
 
     overflow: hidden;
     position: static;
@@ -89,63 +41,4 @@ const SelectContainer = styled.div`
 const SelectContentBox = styled.div`
     display: flex;
     gap: 1rem;
-`;
-
-const SelectWrapperStyle = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 0.7rem;
-`;
-
-const ShowSelectWrapperStyle = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 0.7rem;
-    position: absolute;
-    margin-left: 23.5rem;
-`;
-
-const DropdownMain = styled.div`
-    width: 20rem;
-    padding: 0.8rem 1rem;
-    border: 1px solid rgb(221, 221, 221);
-    border-radius: 0.5rem;
-
-    cursor: pointer;
-
-    display: flex;
-    justify-content: space-between;
-`;
-
-const DropdownListContainer = styled.div`
-    border: 1px solid rgb(221, 221, 221);
-    border-radius: 0.5rem;
-    padding: 0;
-    background-color: white;
-
-    cursor: pointer;
-`;
-
-const DropdownList = styled.ul`
-    list-style: none;
-    padding: 0;
-    margin: 0;
-`;
-
-const ListItem = styled.li`
-    padding: 1rem 0.9rem;
-
-    :first-child {
-        border-top-right-radius: 0.5rem;
-        border-top-left-radius: 0.5rem;
-    }
-
-    :last-child {
-        border-bottom-left-radius: 0.5rem;
-        border-bottom-right-radius: 0.5rem;
-    }
-
-    :hover {
-        background-color: rgb(221, 221, 221);
-    }
 `;

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -19,6 +19,7 @@ export default function Select() {
                 <SelectWrapperStyle>
                     <DropdownMain onClick={() => setIsOpen(!isOpen)}>
                         {selectOption || "React"}
+                        <i class="fa-solid fa-chevron-down"></i>
                     </DropdownMain>
                     {isOpen && (
                         <DropdownListContainer>
@@ -91,6 +92,8 @@ const DropdownMain = styled.div`
     border: 1px solid rgb(221, 221, 221);
     border-radius: 0.5rem;
     cursor: pointer;
+    display: flex;
+    justify-content: space-between;
 `;
 
 const DropdownListContainer = styled.div`

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,44 +1,75 @@
+import { useState } from "react";
 import styled from "styled-components";
 
 export default function Select() {
+    const [isOpen, setIsOpen] = useState(false);
+    const [selectOption, setSelectOption] = useState(null);
+
+    const options = ["React", "JAVA", "Spring", "React Native"];
+
+    const optionClickHandler = (option) => {
+        setSelectOption(option);
+        setIsOpen(false);
+    };
+
     return (
         <SelectContainer>
             <h1>Select</h1>
-            <SelectWrapperStyle>
-                <select>
-                    <option value="" selected>
-                        리액트
-                    </option>
-                    <option>리액트</option>
-                    <option>자바</option>
-                    <option>스프링</option>
-                    <option>리액트 네이티브</option>
-                </select>
-                <select>
-                    <option value="" selected>
-                        리액트
-                    </option>
-                    <option>리액트</option>
-                    <option>자바</option>
-                    <option>스프링</option>
-                    <option>리액트 네이티브</option>
-                </select>
-            </SelectWrapperStyle>
+            <SelectContentBox>
+                <SelectWrapperStyle>
+                    <DropdownMain onClick={() => setIsOpen(!isOpen)}>
+                        {selectOption || "React"}
+                    </DropdownMain>
+                    {isOpen && (
+                        <DropdownListContainer>
+                            <DropdownList>
+                                {options.map((option) => (
+                                    <ListItem
+                                        onClick={() =>
+                                            optionClickHandler(option)
+                                        }
+                                    >
+                                        {option}
+                                    </ListItem>
+                                ))}
+                            </DropdownList>
+                        </DropdownListContainer>
+                    )}
+                </SelectWrapperStyle>
+                <SelectWrapperStyle>
+                    {/* <select>
+                        <option value="" selected>
+                            리액트
+                        </option>
+                        <option>리액트</option>
+                        <option>자바</option>
+                        <option>스프링</option>
+                        <option>리액트 네이티브</option>
+                    </select> */}
+                </SelectWrapperStyle>
+            </SelectContentBox>
         </SelectContainer>
     );
 }
 
 const SelectContainer = styled.div`
     margin-top: 2.5rem;
-    height: 10rem;
+    height: 13rem;
     border: 3px solid rgb(221, 221, 221);
     border-radius: 1rem;
     padding: 0 2rem;
-    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    /* overflow: hidden; */
+`;
+
+const SelectContentBox = styled.div`
+    display: flex;
 `;
 
 const SelectWrapperStyle = styled.div`
     display: flex;
+    flex-direction: column;
     gap: 1rem;
 
     select {
@@ -51,5 +82,45 @@ const SelectWrapperStyle = styled.div`
         padding: 0.8rem 1rem;
         border: 1px solid rgb(221, 221, 221);
         border-radius: 0.5rem;
+    }
+`;
+
+const DropdownMain = styled.div`
+    width: 20rem;
+    padding: 0.8rem 1rem;
+    border: 1px solid rgb(221, 221, 221);
+    border-radius: 0.5rem;
+    cursor: pointer;
+`;
+
+const DropdownListContainer = styled.div`
+    border: 1px solid rgb(221, 221, 221);
+    border-radius: 0.5rem;
+    padding: 0;
+    background-color: white;
+    cursor: pointer;
+`;
+
+const DropdownList = styled.ul`
+    list-style: none;
+    padding: 0;
+    margin: 0;
+`;
+
+const ListItem = styled.li`
+    padding: 1rem 0.9rem;
+
+    :first-child {
+        border-top-right-radius: 0.5rem;
+        border-top-left-radius: 0.5rem;
+    }
+
+    :last-child {
+        border-bottom-left-radius: 0.5rem;
+        border-bottom-right-radius: 0.5rem;
+    }
+
+    :hover {
+        background-color: rgb(221, 221, 221);
     }
 `;

--- a/src/components/select/FirstSelect.js
+++ b/src/components/select/FirstSelect.js
@@ -1,0 +1,35 @@
+import * as Style from "./SelectStyle";
+import { useState } from "react";
+
+export default function FirstSelect({ options, optionClickHandler }) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [selectOption, setSelectOption] = useState(null);
+
+    return (
+        <Style.SelectWrapper>
+            <Style.DropdownMain onClick={() => setIsOpen(!isOpen)}>
+                {selectOption || "React"}
+                <i class="fa-solid fa-chevron-down"></i>
+            </Style.DropdownMain>
+            {isOpen && (
+                <Style.DropdownListContainer>
+                    <Style.DropdownList>
+                        {options.map((option) => (
+                            <Style.ListItem
+                                onClick={() =>
+                                    optionClickHandler(
+                                        option,
+                                        setSelectOption,
+                                        setIsOpen
+                                    )
+                                }
+                            >
+                                {option}
+                            </Style.ListItem>
+                        ))}
+                    </Style.DropdownList>
+                </Style.DropdownListContainer>
+            )}
+        </Style.SelectWrapper>
+    );
+}

--- a/src/components/select/FirstSelect.js
+++ b/src/components/select/FirstSelect.js
@@ -2,15 +2,21 @@ import * as Style from "./SelectStyle";
 import { useState } from "react";
 
 export default function FirstSelect({ options, optionClickHandler }) {
+    // 첫 번째 Select dropdown, option 선택 상태
     const [isOpen, setIsOpen] = useState(false);
     const [selectOption, setSelectOption] = useState(null);
 
     return (
         <Style.SelectWrapper>
+            {/* default select */}
             <Style.DropdownMain onClick={() => setIsOpen(!isOpen)}>
                 {selectOption || "React"}
+
+                {/* 우측 화살표 아이콘 */}
                 <i class="fa-solid fa-chevron-down"></i>
             </Style.DropdownMain>
+
+            {/* select 클릭 시 나오는 dropdown list */}
             {isOpen && (
                 <Style.DropdownListContainer>
                     <Style.DropdownList>

--- a/src/components/select/SecondSelect.js
+++ b/src/components/select/SecondSelect.js
@@ -1,0 +1,35 @@
+import * as Style from "./SelectStyle";
+import { useState } from "react";
+
+export default function SecondSelect({ options, optionClickHandler }) {
+    const [secondOpen, setSecondOpen] = useState(false);
+    const [selectSecondOption, setSelectSecondOption] = useState(null);
+
+    return (
+        <Style.ShowSelectWrapper>
+            <Style.DropdownMain onClick={() => setSecondOpen(!secondOpen)}>
+                {selectSecondOption || "React"}
+                <i class="fa-solid fa-chevron-down" />
+            </Style.DropdownMain>
+            {secondOpen && (
+                <Style.DropdownListContainer>
+                    <Style.DropdownList>
+                        {options.map((option) => (
+                            <Style.ListItem
+                                onClick={() =>
+                                    optionClickHandler(
+                                        option,
+                                        setSelectSecondOption,
+                                        setSecondOpen
+                                    )
+                                }
+                            >
+                                {option}
+                            </Style.ListItem>
+                        ))}
+                    </Style.DropdownList>
+                </Style.DropdownListContainer>
+            )}
+        </Style.ShowSelectWrapper>
+    );
+}

--- a/src/components/select/SecondSelect.js
+++ b/src/components/select/SecondSelect.js
@@ -2,15 +2,21 @@ import * as Style from "./SelectStyle";
 import { useState } from "react";
 
 export default function SecondSelect({ options, optionClickHandler }) {
+    // 두 번째 Select dropdown, option 선택 상태
     const [secondOpen, setSecondOpen] = useState(false);
     const [selectSecondOption, setSelectSecondOption] = useState(null);
 
     return (
         <Style.ShowSelectWrapper>
+            {/* default select */}
             <Style.DropdownMain onClick={() => setSecondOpen(!secondOpen)}>
                 {selectSecondOption || "React"}
+
+                {/* 우측 화살표 아이콘 */}
                 <i class="fa-solid fa-chevron-down" />
             </Style.DropdownMain>
+
+            {/* select 클릭 시 나오는 dropdown list */}
             {secondOpen && (
                 <Style.DropdownListContainer>
                     <Style.DropdownList>

--- a/src/components/select/SelectStyle.js
+++ b/src/components/select/SelectStyle.js
@@ -1,37 +1,23 @@
 import styled from "styled-components";
 
-export const SelectContainer = styled.div`
-    margin-top: 2.5rem;
-    height: 15rem;
-    border: 3px solid rgb(221, 221, 221);
-    border-radius: 1rem;
-    padding: 0 2rem;
-    display: flex;
-    flex-direction: column;
-
-    overflow: hidden;
-    position: static;
-`;
-
-export const SelectContentBox = styled.div`
-    display: flex;
-    gap: 1rem;
-`;
-
+// 부모 컴포넌트의 overflow:hidden이 적용되는 첫 번째 Select
 export const SelectWrapper = styled.div`
     display: flex;
     flex-direction: column;
     gap: 0.7rem;
 `;
 
+// 부모 컴포넌트의 overflow:hidden이 적용되지 않는 두 번째 Select
 export const ShowSelectWrapper = styled.div`
     display: flex;
     flex-direction: column;
+
     gap: 0.7rem;
     position: absolute;
     margin-left: 23.5rem;
 `;
 
+// select 클릭하지 않았을 경우 보이는 default select
 export const DropdownMain = styled.div`
     width: 20rem;
     padding: 0.8rem 1rem;
@@ -44,6 +30,7 @@ export const DropdownMain = styled.div`
     justify-content: space-between;
 `;
 
+// select 클릭 시 나오는 dropdown list container
 export const DropdownListContainer = styled.div`
     border: 1px solid rgb(221, 221, 221);
     border-radius: 0.5rem;
@@ -53,12 +40,14 @@ export const DropdownListContainer = styled.div`
     cursor: pointer;
 `;
 
+// select 클릭 시 나오는 dropdown list ul
 export const DropdownList = styled.ul`
     list-style: none;
     padding: 0;
     margin: 0;
 `;
 
+// select 클릭 시 나오는 각 li 아이템
 export const ListItem = styled.li`
     padding: 1rem 0.9rem;
 

--- a/src/components/select/SelectStyle.js
+++ b/src/components/select/SelectStyle.js
@@ -1,0 +1,78 @@
+import styled from "styled-components";
+
+export const SelectContainer = styled.div`
+    margin-top: 2.5rem;
+    height: 15rem;
+    border: 3px solid rgb(221, 221, 221);
+    border-radius: 1rem;
+    padding: 0 2rem;
+    display: flex;
+    flex-direction: column;
+
+    overflow: hidden;
+    position: static;
+`;
+
+export const SelectContentBox = styled.div`
+    display: flex;
+    gap: 1rem;
+`;
+
+export const SelectWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+`;
+
+export const ShowSelectWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+    position: absolute;
+    margin-left: 23.5rem;
+`;
+
+export const DropdownMain = styled.div`
+    width: 20rem;
+    padding: 0.8rem 1rem;
+    border: 1px solid rgb(221, 221, 221);
+    border-radius: 0.5rem;
+
+    cursor: pointer;
+
+    display: flex;
+    justify-content: space-between;
+`;
+
+export const DropdownListContainer = styled.div`
+    border: 1px solid rgb(221, 221, 221);
+    border-radius: 0.5rem;
+    padding: 0;
+    background-color: white;
+
+    cursor: pointer;
+`;
+
+export const DropdownList = styled.ul`
+    list-style: none;
+    padding: 0;
+    margin: 0;
+`;
+
+export const ListItem = styled.li`
+    padding: 1rem 0.9rem;
+
+    :first-child {
+        border-top-right-radius: 0.5rem;
+        border-top-left-radius: 0.5rem;
+    }
+
+    :last-child {
+        border-bottom-left-radius: 0.5rem;
+        border-bottom-right-radius: 0.5rem;
+    }
+
+    :hover {
+        background-color: rgb(221, 221, 221);
+    }
+`;


### PR DESCRIPTION
## 개요
select component 완료
## 작업 사항
- [public/index.html] fontawesome icon script를 추가했습니다.
- [src/components/select]
  - [/FirstSelect.js] 부모 컴포넌트의 `overflow:hidden`이 적용되는 Select 컴포넌트입니다.
  - [/SecondSelect.js] 부모 컴포넌트의 `overflow:hidden`이 적용되지 않는 Select 컴포넌트입니다.
  - [/SelectStyle.js] 각 Select에 적용되는 styled-components 코드입니다.
- [src/components/Select.js] 두 Select가 들어가는 컴포넌트입니다.
- 그 외 주석 추가, 필요없는 코드 삭제
## 개선점
- props로 내리는 상태가 많아서 컴포넌트 분리를 충분히 하지 못했는데, 상태관리 툴을 사용해 컴포넌트 분리를 더 해야 할 필요성을 느꼈습니다. 
- 부모 컴포넌트의 `overflow:hidden`이 적용되지 않게 하기 위해 `position: static`,  `position: absolute`를 활용해서 구현했는데, 이렇게 하는게 맞는건지 확신이 서지 않습니다. 그래도 과제 조건 그대로 작동은 됨,,^^
- 첫 번째 select와 두 번째 select 간 반복되는 로직이 있는데, 상태값을 다르게 써야 해서 그냥 같은 로직을 다른 상태값으로 구현했지만, 개선이 필요합니다.